### PR TITLE
Add #[lisp_fn] procedural macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rand"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +114,16 @@ version = "0.1.0"
 dependencies = [
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "orbclient 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rselisp-macros"
+version = "0.1.0"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rselisp 0.1.0",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -132,6 +147,29 @@ dependencies = [
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
 [metadata]
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
@@ -146,7 +184,11 @@ dependencies = [
 "checksum num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "7485fcc84f85b4ecd0ea527b14189281cf27d60e583ae65ebc9c088b13dffe01"
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
 "checksum orbclient 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "6e5d8d9900998fb4b9394e27058aa22a6d3509fb67dd860f74ba0507d4406943"
+"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb250fd207a4729c976794d03db689c9be1d634ab5a1c9da9492a13d8fecbcdf"
 "checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
 "checksum sdl2 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "63066036ad426250ac56d23e38fd05063b38b661556acd596f4046cc92d98415"
 "checksum sdl2-sys 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b48638b7882759f3421038fcd38ad5f1ea19b119d80c99f1601933004629e34d"
+"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "rselisp"
 version = "0.1.0"
 authors = ["Richard Palethorpe <richiejp@f-m.fm>"]
 
+[workspace]
+members = ["rselisp-macros"]
+
 [dependencies]
 fnv = "*"
 orbclient = "*"

--- a/rselisp-macros/Cargo.toml
+++ b/rselisp-macros/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rselisp-macros"
+version = "0.1.0"
+authors = ["Jean Pierre Dudey <jeandudey@hotmail.com>"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "0.11.11", features = ["full"] }
+synom = "0.11.3"
+quote = "0.3.15"
+
+[dev-dependencies]
+rselisp = { path = "../" }

--- a/rselisp-macros/src/attr.rs
+++ b/rselisp-macros/src/attr.rs
@@ -1,0 +1,49 @@
+use syn;
+
+#[derive(Debug)]
+pub struct LispFn {
+    /// Defines if the function is evaluated or unevaluated.
+    pub eval_option: EvalOption,
+}
+
+#[derive(Debug)]
+pub enum EvalOption {
+    Evaluated,
+    Unevaluated,
+}
+
+pub fn parse(attr: syn::Attribute) -> Result<LispFn, ()> {
+    let mut lisp_fn = LispFn { eval_option: EvalOption::Evaluated };
+    match attr.value {
+        // #[lisp_fn] form
+        syn::MetaItem::Word(_) => {},
+        // #[lisp_fn(..)] form
+        syn::MetaItem::List(_, meta_items) => {
+            for entry in meta_items {
+                match entry {
+                    syn::NestedMetaItem::MetaItem(meta_item) => {
+                        match meta_item {
+                            syn::MetaItem::Word(ident) => {
+                                match ident.as_ref() {
+                                    "unevaluated" => {
+                                        lisp_fn.eval_option = EvalOption::Unevaluated;
+                                    }
+                                    "evaluated" => {
+                                        lisp_fn.eval_option = EvalOption::Evaluated;
+                                    }
+                                    _ => return Err(())
+                                }
+                            }
+                            _ => return Err(()),
+                        }
+                    }
+                    _ => return Err(()),
+                }
+            }
+        }
+        // not valid syntax
+        _=> return Err(())
+    }
+
+    Ok(lisp_fn)
+}

--- a/rselisp-macros/src/func.rs
+++ b/rselisp-macros/src/func.rs
@@ -1,0 +1,19 @@
+use syn;
+
+#[derive(Debug)]
+pub struct Function {
+    pub name: syn::Ident,
+}
+
+pub fn parse(item: &syn::Item) -> Result<Function, ()> {
+    let name = item.ident.clone();
+
+    match item.node {
+        syn::ItemKind::Fn(_, _, _, _, _, _) => {}
+        _ => return Err(())
+    }
+
+    Ok(Function {
+        name,
+    })
+}

--- a/rselisp-macros/src/lib.rs
+++ b/rselisp-macros/src/lib.rs
@@ -1,0 +1,71 @@
+#![feature(proc_macro)]
+#![recursion_limit="128"]
+
+extern crate proc_macro;
+extern crate synom;
+extern crate syn;
+#[macro_use]
+extern crate quote;
+
+use std::str::FromStr;
+use proc_macro::TokenStream;
+
+mod func;
+mod attr;
+
+#[proc_macro_attribute]
+pub fn lisp_fn(attr_ts: TokenStream, fn_ts: TokenStream) -> TokenStream {
+    let attr_ts = attr_ts.to_string();
+    let real_attr = if attr_ts.len() > 0 {
+        format!("#[lisp_fn({})]", attr_ts)
+    } else {
+        "#[lisp_fn]".to_string()
+    };
+
+    let fn_item = syn::parse_item(&fn_ts.to_string()).unwrap();
+    let attr = attr::parse(syn::parse_outer_attr(&real_attr.to_string()).unwrap()).unwrap();
+    let func = func::parse(&fn_item).unwrap();
+
+    let eval_opt_toks = match attr.eval_option {
+        attr::EvalOption::Evaluated => {
+            quote! { ::rselisp::lambda::EvalOption::Evaluated }
+        }
+        attr::EvalOption::Unevaluated => {
+            quote! { ::rselisp::lambda::EvalOption::Unevaluated }
+        }
+    };
+
+    let rname = {
+        let name = format!("{}", func.name);
+        let c = name.chars().next().map(|c| c.to_uppercase()).unwrap();
+        syn::Ident::new(format!("{}{}Builtin", c, name.split_at(1).1))
+    };
+
+    let name = func.name.clone();
+
+    let tokens = quote! {
+        #[derive(Clone, Debug)]
+        pub struct #rname {
+            name: ::rselisp::symbols::Atom,
+        }
+
+        impl ::rselisp::lambda::Func for #rname {
+            fn eval_args(&self) -> ::rselisp::lambda::EvalOption {
+                #eval_opt_toks
+            }
+
+            fn name(&self) -> ::rselisp::symbols::Atom {
+                self.name
+            }
+
+            fn call(&self, lsp: &mut ::rselisp::Lsp, args: &mut std::slice::Iter<::rselisp::LispObj>)
+                -> Result<::rselisp::LispObj, String> {
+                #name(lsp, args)
+            }
+        }
+
+        #fn_item
+    };
+
+    TokenStream::from_str(tokens.as_str()).unwrap()
+}

--- a/rselisp-macros/tests/basic.rs
+++ b/rselisp-macros/tests/basic.rs
@@ -1,0 +1,14 @@
+#![feature(proc_macro)]
+
+extern crate rselisp;
+extern crate rselisp_macros;
+
+use std::slice::Iter;
+
+use rselisp::{Lsp, LispObj};
+use rselisp_macros::lisp_fn;
+
+#[lisp_fn]
+fn foobar(_lsp: &mut Lsp, _args: &mut Iter<LispObj>) -> Result<LispObj, String> {
+    Ok(LispObj::Int(0xDEADC0DEi32))
+}


### PR DESCRIPTION
Functions like this:

```rust
def_builtin! { "print", PrintBuiltin, Evaluated, lsp, args; {
    let mut s = String::new();
    lsp.print_itr(&mut s, args.peekable());
    println!("{}", &s);
    Ok(LispObj::Str(s))
}}
```

Can now be:

```rust
// or if you are explicit #[lisp_fn(evaluated)], or #[lisp_fn(unevaluated)].
#[lisp_fn]
pub fn print(lsp: Lsp, args: &mut Iter<LispObj>) -> Result<LispObj, String> {
    let mut s = String::new();
    lsp.print_itr(&mut s, args.peekable());
    println!("{}", &s);
    Ok(LispObj::Str(s))
}}
```

And defines `PrintBuilting` with a little bit of magic.

Notes:

- This does not work inside the rselisp crate only outside
- There is no way to represent function like minus ("-"), but this is trivial to solve.
- It would be great if arguments are passed in a fixed manner instead of having an array. (e.g: `fn foo(a1: LispObj, a2: LispObj)`)